### PR TITLE
Handle no preview image available

### DIFF
--- a/javascript/statemanager.js
+++ b/javascript/statemanager.js
@@ -1330,7 +1330,9 @@
         const galleryPreviews = sm.getGalleryPreviews();
     
         const image = (galleryPreviews.length > 1 && galleryPreviews[0].src.includes("grids/")) ? galleryPreviews[1] : galleryPreviews[0];
-    
+        if (!image) {
+            return undefined;
+        }
         // const imageSize = {x: 100, y: 100};
     
         const scale = 100 / Math.max(image.naturalWidth, image.naturalHeight);


### PR DESCRIPTION
In some situations, like if the generation has been interrupted before a preview has been generated, no preview image exists. This leads to errors when trying to generate later, which means that the webUI must be reloaded and everything is "reset" (which is a hassle).

I don't know if this is the best way to solve it, but I've tested it for some time and it seems to take care of the problem.