### PR TITLE
Fixes warnings about Gradio (v4.40.0) related code being deprecated on Stable Diffusion Forge

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -142,6 +142,9 @@ def on_ui_settings():
 
 def statemanager_option_button_component(py_click, js_click, **kwargs):
     class_list = "sd-webui-statemanager-option-button " + kwargs.pop('elem_classes', '')
+    # Remove 'label' from kwargs if it exists
+    if 'label' in kwargs:
+        kwargs.pop('label')
     button = gr.Button(elem_classes=class_list, **kwargs)
 
     if str(gr.__version__[0]) == "3":
@@ -153,7 +156,20 @@ def statemanager_option_button_component(py_click, js_click, **kwargs):
 
 class StateManagerOptionButton(shared.OptionInfo):
     def __init__(self, text, py_click, js_click, **kwargs):
-        super().__init__(str(text).strip(), label='', component=lambda **lkwargs: statemanager_option_button_component(py_click, js_click, **{**kwargs, **lkwargs}))
+        # Use the text parameter as the button's text instead of a label
+        button_kwargs = {**kwargs}
+        if 'label' in button_kwargs:
+            button_kwargs.pop('label')
+        super().__init__(
+            str(text).strip(), 
+            label=None,  # Set label to None since we don't need it for buttons
+            component=lambda **lkwargs: statemanager_option_button_component(
+                py_click, 
+                js_click, 
+                text=text,  # Pass text directly to the button
+                **{**button_kwargs, **lkwargs}
+            )
+        )
         self.do_not_save = True
 
 shared.options_templates.update(

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -142,10 +142,11 @@ def on_ui_settings():
 
 def statemanager_option_button_component(py_click, js_click, **kwargs):
     class_list = "sd-webui-statemanager-option-button " + kwargs.pop('elem_classes', '')
-    # Remove 'label' from kwargs if it exists
+    # Remove 'label' and 'text' from kwargs, use text as the button's label
     if 'label' in kwargs:
         kwargs.pop('label')
-    button = gr.Button(elem_classes=class_list, **kwargs)
+    text = kwargs.pop('text') if 'text' in kwargs else ""
+    button = gr.Button(text, elem_classes=class_list, **kwargs)
 
     if str(gr.__version__[0]) == "3":
         button.click(fn=py_click, _js=js_click)
@@ -156,17 +157,19 @@ def statemanager_option_button_component(py_click, js_click, **kwargs):
 
 class StateManagerOptionButton(shared.OptionInfo):
     def __init__(self, text, py_click, js_click, **kwargs):
-        # Use the text parameter as the button's text instead of a label
+        # Remove label and text from button_kwargs to avoid duplication
         button_kwargs = {**kwargs}
         if 'label' in button_kwargs:
             button_kwargs.pop('label')
+        if 'text' in button_kwargs:
+            button_kwargs.pop('text')
         super().__init__(
             str(text).strip(), 
             label=None,  # Set label to None since we don't need it for buttons
             component=lambda **lkwargs: statemanager_option_button_component(
                 py_click, 
                 js_click, 
-                text=text,  # Pass text directly to the button
+                text=text,  # This will be extracted and used as the first argument
                 **{**button_kwargs, **lkwargs}
             )
         )


### PR DESCRIPTION
The title explains it shortly.
An annoying warning got served every time launching Stable Diffusion Forge about certain gradio related code being deprecated, and this PR fixes those annoying "warnings" on my updated Stable Diffusion Forge running Gradio v4.40.0 to be exact.
I tested one fix that didn't work, before my second attempt worked flawlessly.

Here's the "annoying error" code mentioned:
```
D:\stable-diffusion-forge\webui\extensions\sd-webui-state-manager\scripts\api.py:145: GradioDeprecationWarning: unexpected argument for Button: label
  button = gr.Button(elem_classes=class_list, **kwargs)
  ```
  
  If this error is not present on Stable Diffusion, it will most definetly be present when they upgrade their Gradio code.
  By looking at the code, i don't think this will affect regular "Stable Diffusion" (AUTOMATIC1111) itself. But feel fry to test it out yourself. 
  
  Hope this was helpful. Even if it was just a warning, i'm glad to can assist in any way :)